### PR TITLE
Laravel 5.6 and 5.7 support

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -20,7 +20,7 @@ checks:
 tools:
     external_code_coverage:
         timeout: 600
-        runs: 3
+        runs: 5
 
 build:
     nodes:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,26 @@
 language: php
 
-php:
-  - '7.0'
-  - '7.1'
-  - '7.2'
+matrix:
+  include:
+  - php: "7.0"
+    env: LARAVEL_VERSION="5.5.*"
+  - php: "7.1"
+    env: LARAVEL_VERSION="5.5.*"
+  - php: "7.2"
+    env: LARAVEL_VERSION="5.5.*"
+  - php: "7.2"
+    env: LARAVEL_VERSION="5.6.*"
+  - php: "7.2"
+    env: LARAVEL_VERSION="5.7.*" RUN_CS_FIXER=1
 
 sudo: false
 
 install:
+  - composer require "illuminate/http:${LARAVEL_VERSION}" "illuminate/routing:${LARAVEL_VERSION}" "illuminate/support:${LARAVEL_VERSION}" --no-update --no-interaction
   - travis_retry composer install --no-interaction --prefer-dist
 
 script:
-  - vendor/bin/php-cs-fixer fix -v --dry-run --using-cache=no
+  - if [ "$RUN_CS_FIXER" ] ; then vendor/bin/php-cs-fixer fix -v --dry-run --using-cache=no ; fi
   - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.xml
 
 after_script:

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
     ],
     "require": {
         "php" : ">=7.0",
-        "illuminate/http": "^5.0,<5.6",
-        "illuminate/routing": "^5.0,<5.6",
-        "illuminate/support": "^5.0,<5.6"
+        "illuminate/http": "^5.0,<5.8",
+        "illuminate/routing": "^5.0,<5.8",
+        "illuminate/support": "^5.0,<5.8"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",
         "orchestra/testbench": "^3.5",
-        "phpunit/phpunit": "^6.1"
+        "phpunit/phpunit": "^6.1|^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I added support for Laravel 5.6 and 5.7. I also changed the Travis config so it tests Laravel 5.1-5.7.

## Motivation and context

Support was missing, but desired. This fixes #1.

## How has this been tested?

Tested using existing unit tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
