### PR TITLE
Laravel 5.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: php
 
 matrix:
   include:
-  - php: "7.0"
-    env: LARAVEL_VERSION="5.5.*"
   - php: "7.1"
     env: LARAVEL_VERSION="5.5.*"
   - php: "7.2"
@@ -11,7 +9,9 @@ matrix:
   - php: "7.2"
     env: LARAVEL_VERSION="5.6.*"
   - php: "7.2"
-    env: LARAVEL_VERSION="5.7.*" RUN_CS_FIXER=1
+    env: LARAVEL_VERSION="5.7.*"
+  - php: "7.2"
+    env: LARAVEL_VERSION="5.8.*" RUN_CS_FIXER=1
 
 sudo: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `swisnl/laravel-javascript-data-response` will be documen
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## [Unreleased]
+
+### Added
+- Added support for Laravel 5.8.
+
+### Changed
+- Dropped Laravel <5.5 support.
+- Dropped PHP <7.1 support.
+
 ## 1.0.0 - 2018-09-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,17 +16,6 @@ JavaScript data response macro for Laravel
 $ composer require swisnl/laravel-javascript-data-response
 ```
 
-### Laravel Service Provider
-
-If you are using Laravel < 5.5 or have disabled package auto discover, you must add the service provider to your `config/app.php` file:
-
-``` php
-'providers' => [
-    ...,
-    \Swis\Laravel\JavaScriptData\ServiceProvider::class,
-],
-```
-
 ## Usage
 
 This package adds a response macro (similar to Response::jsonp) which you can use just like any other response e.g.

--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,15 @@
         }
     ],
     "require": {
-        "php" : ">=7.0",
-        "illuminate/http": "^5.0,<5.8",
-        "illuminate/routing": "^5.0,<5.8",
-        "illuminate/support": "^5.0,<5.8"
+        "php" : ">=7.1.3",
+        "illuminate/http": "5.5.*|5.6.*|5.7.*|5.8.*",
+        "illuminate/routing": "5.5.*|5.6.*|5.7.*|5.8.*",
+        "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",
-        "orchestra/testbench": "^3.5",
-        "phpunit/phpunit": "^6.1|^7.0"
+        "graham-campbell/testbench": "^5.1",
+        "phpunit/phpunit": "^6.1|^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -114,13 +114,11 @@ class BuilderTest extends TestCase
 
     /**
      * @test
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionCode 5
-     * @expectedExceptionMessage Malformed UTF-8 characters, possibly incorrectly encoded
      */
     public function itThrowsWhenJsonEncodeFailed()
     {
+        $this->expectExceptionObject(new \InvalidArgumentException('Malformed UTF-8 characters, possibly incorrectly encoded', 5));
+
         $builder = new Builder();
         $builder->build('namespace', "\x80");
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I've added support for Laravel 5.8.

## Motivation and context

Laravel 5.8 is out and about! I had to drop PHP <7.1 and Laravel <5.5 support in order to make it compatible. But since these are both EOL, I think it is appropriate to do so!

## How has this been tested?

Tested with existing unit tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added/updated tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
